### PR TITLE
docs: add Three.js resource links

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,5 +188,5 @@ This repository contains **step-by-step lessons** that teach **3D graphics, inte
 ---
 
 <p align="center">
-  🌟 Built with ❤️ and Three.js · <strong>Learn · Teach · Build Worlds</strong>
+  🌟 Built with ❤️ and Three.js · <strong>Learn · Teach · @maxkamjon.abdumannobov</strong>
 </p>

--- a/README.md
+++ b/README.md
@@ -180,6 +180,11 @@ This repository contains **step-by-step lessons** that teach **3D graphics, inte
 - Lessons 9–18 = **advanced graphics, shaders, particles, postprocessing**  
 - Lessons 19–21 = **final open-world interactive project**  
 
+- [Three.js Docs](https://threejs.org/docs/): Official API reference for the entire library
+- [Discover three.js](https://discoverthreejs.com/): Project-based tutorials that build real applications step by step
+- [Three.js Fundamentals](https://threejsfundamentals.org/): Beginner-friendly explanations of core concepts with interactive examples
+- [The Book of Shaders](https://thebookofshaders.com/): Creative guide to writing shaders with GLSL
+
 ---
 
 <p align="center">


### PR DESCRIPTION
## Summary
- add links to Three.js docs, Discover three.js, Three.js Fundamentals, and The Book of Shaders after Endgame Vision

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c839b6ef708333bde6fc71f47fd0c9