### PR TITLE
Align lesson 2 group examples with baseline positions

### DIFF
--- a/02-lesson/02-shapes.html
+++ b/02-lesson/02-shapes.html
@@ -48,7 +48,7 @@ function addTriangle(x,y,w,h,color){
   mesh.position.set(x, y, 0);
   return mesh;
 }
-const square = addSquare(80,80,120,0xffffff);
+const square = addSquare(80,100,120,0xffffff);
 const triangle = addTriangle(240,100,140,120,0x00ccff);
 scene.add(square);
 scene.add(triangle);

--- a/02-lesson/03-group-create.html
+++ b/02-lesson/03-group-create.html
@@ -49,7 +49,7 @@ function addTriangle(x,y,w,h,color){
   return mesh;
 }
 const group = new THREE.Group();
-const square = addSquare(80,80,120,0xffffff);
+const square = addSquare(80,100,120,0xffffff);
 const triangle = addTriangle(240,100,140,120,0x00ccff);
 group.add(square);
 group.add(triangle);

--- a/02-lesson/04-group-move.html
+++ b/02-lesson/04-group-move.html
@@ -49,10 +49,10 @@ function addTriangle(x,y,w,h,color){
   return mesh;
 }
 const group = new THREE.Group();
-const square = addSquare(80,80,120,0xffffff);
+const square = addSquare(80,100,120,0xffffff);
 const triangle = addTriangle(240,100,140,120,0x00ccff);
 group.add(square); group.add(triangle);
-group.position.set(60, 40, 0); // move whole group
+group.position.set(0, 0, 0);
 scene.add(group);
 
 function tick() { resize(); renderer.render(scene, cam); requestAnimationFrame(tick); }

--- a/02-lesson/05-group-rotate.html
+++ b/02-lesson/05-group-rotate.html
@@ -49,10 +49,10 @@ function addTriangle(x,y,w,h,color){
   return mesh;
 }
 const group = new THREE.Group();
-const square = addSquare(80,80,120,0xffffff);
+const square = addSquare(80,100,120,0xffffff);
 const triangle = addTriangle(240,100,140,120,0x00ccff);
 group.add(square); group.add(triangle);
-group.position.set(160, 80, 0);
+group.position.set(0, 0, 0);
 scene.add(group);
 
 let rotatingGroup = false;

--- a/02-lesson/06-group-and-individual.html
+++ b/02-lesson/06-group-and-individual.html
@@ -49,10 +49,10 @@ function addTriangle(x,y,w,h,color){
   return mesh;
 }
 const group = new THREE.Group();
-const square = addSquare(80,80,120,0xffffff);
+const square = addSquare(80,100,120,0xffffff);
 const triangle = addTriangle(240,100,140,120,0x00ccff);
 group.add(square); group.add(triangle);
-group.position.set(160, 80, 0);
+group.position.set(0, 0, 0);
 scene.add(group);
 
 let rotatingGroup = true;

--- a/02-lesson/07-toggles.html
+++ b/02-lesson/07-toggles.html
@@ -49,10 +49,10 @@ function addTriangle(x,y,w,h,color){
   return mesh;
 }
 const group = new THREE.Group();
-const square = addSquare(80,80,120,0xffffff);
+const square = addSquare(80,100,120,0xffffff);
 const triangle = addTriangle(240,100,140,120,0x00ccff);
 group.add(square); group.add(triangle);
-group.position.set(160, 80, 0);
+group.position.set(0, 0, 0);
 scene.add(group);
 
 let rotatingGroup = true;


### PR DESCRIPTION
## Summary
- align the Lesson 2 square placement with the Lesson 1 baseline by moving it to (80, 100)
- reset group origins to (0, 0, 0) in the transformation steps so subsequent movements and rotations start from the baseline pose

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68c9535770c08333927efbdd20a56b9a