### PR TITLE
Align lesson 3 shapes with new positions

### DIFF
--- a/03-lesson/02-shapes.html
+++ b/03-lesson/02-shapes.html
@@ -66,7 +66,7 @@ function getMouseScenePos(e){
 }
 
 const square = addSquare(80,80,120,0xffffff);
-const triangle = addTriangle(260,100,140,120,0x00ccff);
+const triangle = addTriangle(240,100,140,120,0x00ccff);
 scene.add(square); scene.add(triangle);
 function tick(){ resize(); renderer.render(scene, cam); requestAnimationFrame(tick); }
 requestAnimationFrame(tick);

--- a/03-lesson/03-keys-move-square.html
+++ b/03-lesson/03-keys-move-square.html
@@ -65,8 +65,8 @@ function getMouseScenePos(e){
   return {x,y};
 }
 
-const square = addSquare(120,120,120,0xffffff);
-const triangle = addTriangle(340,140,140,120,0x00ccff);
+const square = addSquare(80,80,120,0xffffff);
+const triangle = addTriangle(240,100,140,120,0x00ccff);
 scene.add(square); scene.add(triangle);
 
 const keys = {ArrowLeft:false,ArrowRight:false,ArrowUp:false,ArrowDown:false};

--- a/03-lesson/04-keys-reset-space.html
+++ b/03-lesson/04-keys-reset-space.html
@@ -65,9 +65,9 @@ function getMouseScenePos(e){
   return {x,y};
 }
 
-const start = {x:180,y:160};
+const start = {x:80,y:80};
 const square = addSquare(start.x,start.y,120,0xffffff);
-const triangle = addTriangle(380,160,140,120,0x00ccff);
+const triangle = addTriangle(240,100,140,120,0x00ccff);
 scene.add(square); scene.add(triangle);
 
 const keys = {ArrowLeft:false,ArrowRight:false,ArrowUp:false,ArrowDown:false};

--- a/03-lesson/05-mouse-follow-triangle.html
+++ b/03-lesson/05-mouse-follow-triangle.html
@@ -65,9 +65,9 @@ function getMouseScenePos(e){
   return {x,y};
 }
 
-const square = addSquare(120,120,120,0xffffff);
+const square = addSquare(80,80,120,0xffffff);
 const triW=140, triH=120;
-const triangle = addTriangle(360,160,triW,triH,0x00ccff);
+const triangle = addTriangle(240,100,triW,triH,0x00ccff);
 scene.add(square); scene.add(triangle);
 
 addEventListener('mousemove', e=>{

--- a/03-lesson/06-hover-highlight.html
+++ b/03-lesson/06-hover-highlight.html
@@ -66,8 +66,8 @@ function getMouseScenePos(e){
 }
 
 const sqSize=120, triW=140, triH=120;
-const square = addSquare(120,120,sqSize,0xffffff);
-const triangle = addTriangle(360,160,triW,triH,0x00ccff);
+const square = addSquare(80,80,sqSize,0xffffff);
+const triangle = addTriangle(240,100,triW,triH,0x00ccff);
 scene.add(square); scene.add(triangle);
 
 const COLOR_SQ = 0xffffff, COLOR_SQ_HOVER=0xffd166;

--- a/03-lesson/07-combine-inputs.html
+++ b/03-lesson/07-combine-inputs.html
@@ -66,9 +66,9 @@ function getMouseScenePos(e){
 }
 
 const sqSize=120, triW=140, triH=120;
-const start = {x:160,y:160};
+const start = {x:80,y:80};
 const square = addSquare(start.x,start.y,sqSize,0xffffff);
-const triangle = addTriangle(420,200,triW,triH,0x00ccff);
+const triangle = addTriangle(240,100,triW,triH,0x00ccff);
 scene.add(square); scene.add(triangle);
 
 // keyboard (square)


### PR DESCRIPTION
## Summary
- place the square at (80, 80) across the interactive lesson pages
- move the triangle start location to (240, 100) for consistent layout
- update reset defaults to match the new starting coordinates

## Testing
- not run (html updates only)


------
https://chatgpt.com/codex/tasks/task_e_68c95a78b2908333aac0d2c5221d1e11