### PR TITLE
Update lesson overview links to renamed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Please respect author's hardwork.
 ## 🟦 Lesson 1 — Intro Scene
 **Goal:** First contact with Three.js. Setup renderer, camera, and add simple shapes.
 
-- [01 — Renderer](/01-lesson/step-1.html)  
-- [02 — Ortho Camera](/01-lesson/step-2.html)  
-- [03 — Square](/01-lesson/step-3.html)  
-- [04 — Triangle](/01-lesson/step-4.html)  
-- [05 — Toggles](/01-lesson/step-5.html)  
-- [06 — Rotate Z](/01-lesson/step-6.html)  
-- [07 — Rotate Y](/01-lesson/step-7.html)  
+- [01 — Renderer](/01-lesson/01-01-renderer.html)
+- [02 — Ortho Camera](/01-lesson/01-02-ortho-camera.html)
+- [03 — Square](/01-lesson/01-03-square.html)
+- [04 — Triangle](/01-lesson/01-04-triangle.html)
+- [05 — Toggles](/01-lesson/01-05-toggles.html)
+- [06 — Rotate Z](/01-lesson/01-06-rotate-z.html)
+- [07 — Rotate Y](/01-lesson/01-07-rotate-y.html)
 
 📸 _Learner sees: static → moving 2D primitives with basic rotations._
 
@@ -64,13 +64,13 @@ Please respect author's hardwork.
 ## 🔶 Lesson 2 — Multiple Objects & Grouping
 **Goal:** Learn how to combine meshes into groups, move/rotate them together, and contrast with independent meshes.
 
-- [01 — Renderer + Ortho](/02-lesson/01-renderer.html)  
-- [02 — Shapes Refresh](/02-lesson/02-shapes.html)  
-- [03 — Create Group](/02-lesson/03-group-create.html)  
-- [04 — Move Group](/02-lesson/04-group-move.html)  
-- [05 — Rotate Group](/02-lesson/05-group-rotate.html)  
-- [06 — Group + Individual](/02-lesson/06-group-and-individual.html)  
-- [07 — Toggles](/02-lesson/07-toggles.html)  
+- [01 — Renderer + Ortho](/02-lesson/02-01-renderer.html)
+- [02 — Shapes Refresh](/02-lesson/02-02-shapes.html)
+- [03 — Create Group](/02-lesson/02-03-group-create.html)
+- [04 — Move Group](/02-lesson/02-04-group-move.html)
+- [05 — Rotate Group](/02-lesson/02-05-group-rotate.html)
+- [06 — Group + Individual](/02-lesson/02-06-group-and-individual.html)
+- [07 — Toggles](/02-lesson/02-07-toggles.html)
 
 📸 _Learner sees: groups vs independent objects; group transform differences._
 
@@ -79,13 +79,13 @@ Please respect author's hardwork.
 ## 🟥 Lesson 3 — Transformations & Input
 **Goal:** Introduce keyboard and mouse input to manipulate objects.
 
-- [01 — Renderer + Ortho](/03-lesson/01-renderer.html)  
-- [02 — Shapes Review](/03-lesson/02-shapes.html)  
-- [03 — Arrow Keys Move](/03-lesson/03-keys-move-square.html)  
-- [04 — Space Reset](/03-lesson/04-keys-reset-space.html)  
-- [05 — Mouse Follow](/03-lesson/05-mouse-follow-triangle.html)  
-- [06 — Group Move + Scale](/03-lesson/06-group-move-scale.html)  
-- [07 — Final Mini Demo](/03-lesson/07-final-mini-demo.html)  
+- [01 — Renderer + Ortho](/03-lesson/03-01-renderer.html)
+- [02 — Shapes Review](/03-lesson/03-02-shapes.html)
+- [03 — Arrow Keys Move](/03-lesson/03-03-keys-move-square.html)
+- [04 — Space Reset](/03-lesson/03-04-keys-reset-space.html)
+- [05 — Mouse Follow](/03-lesson/03-05-mouse-follow-triangle.html)
+- [06 — Group Move + Scale](/03-lesson/03-06-hover-highlight.html)
+- [07 — Final Mini Demo](/03-lesson/03-07-combine-inputs.html)
 
 📸 _Learner sees: interactive movement, reset keys, mouse-follow mechanics._
 
@@ -94,13 +94,13 @@ Please respect author's hardwork.
 ## 🟩 Lesson 4 — Animations & Camera Toggles
 **Goal:** Toggle between perspective/ortho, rotate shapes, combine 2D↔3D pairs.
 
-- [01 — Ortho Refresher](/04-lesson/01-ortho-refresher.html)  
-- [02 — Shapes Ortho](/04-lesson/02-shapes-ortho.html)  
-- [03 — Toggle Cameras](/04-lesson/03-toggle-cameras.html)  
-- [04 — Z Depth](/04-lesson/04-z-depth.html)  
-- [05 — 2D↔3D Toggle Pairs](/04-lesson/05-paired-toggles.html)  
-- [06 — Rotating 3D Pairs](/04-lesson/06-rotating-pairs.html)  
-- [07 — Final 2D↔3D Demo](/04-lesson/07-final.html)  
+- [01 — Ortho Refresher](/04-lesson/04-01-ortho-refresher.html)
+- [02 — Shapes Ortho](/04-lesson/04-02-shapes-ortho.html)
+- [03 — Toggle Cameras](/04-lesson/04-03-toggle-cameras.html)
+- [04 — Z Depth](/04-lesson/04-04-z-depth.html)
+- [05 — 2D↔3D Toggle Pairs](/04-lesson/04-05-paired-toggles.html)
+- [06 — Rotating 3D Pairs](/04-lesson/04-06-rotating-pairs.html)
+- [07 — Final 2D↔3D Demo](/04-lesson/04-07-final.html)
 
 📸 _Learner sees: perspective vs ortho, toggling between 2D and 3D forms._
 
@@ -109,13 +109,13 @@ Please respect author's hardwork.
 ## 🟪 Lesson 5 — Materials
 **Goal:** Explore material types — basic, metallic, transparent — and add orbit controls.
 
-- [01 — Scene + 2D Shapes](/05-lesson/01-Scene-and-2D-shapes.html)  
-- [02 — 3D Counterparts + Lights](/05-lesson/02-Add-3D-counterparts-and-lights.html)  
-- [03 — Group + Animation](/05-lesson/03-Group-and-Animation.html)  
-- [04 — Ortho Camera + Switch Keys](/05-lesson/04-Orthographic-camera-and-switch.html)  
-- [05 — Orbit Controls (Drag/Wheel)](/05-lesson/05-Orbit-controls-drag-and-zoom.html)  
-- [06 — DPR-aware Resize](/05-lesson/06-DPR-aware-resize.html)  
-- [07 — HUD + Toggles](/05-lesson/07-HUD-and-runtime-toggles.html)  
+- [01 — Scene + 2D Shapes](/05-lesson/05-01-Scene-and-2D-shapes.html)
+- [02 — 3D Counterparts + Lights](/05-lesson/05-02-Add-3D-counterparts-and-lights.html)
+- [03 — Group + Animation](/05-lesson/05-03-Group-and-Animation.html)
+- [04 — Ortho Camera + Switch Keys](/05-lesson/05-04-Orthographic-camera-and-switch.html)
+- [05 — Orbit Controls (Drag/Wheel)](/05-lesson/05-05-Orbit-controls-drag-and-zoom.html)
+- [06 — DPR-aware Resize](/05-lesson/05-06-DPR-aware-resize.html)
+- [07 — HUD + Toggles](/05-lesson/05-07-HUD-and-runtime-toggles.html)
 
 📸 _Learner sees: different materials side by side, with orbit & resize responsiveness._
 
@@ -124,13 +124,13 @@ Please respect author's hardwork.
 ## 🟧 Lesson 6 — Extended Materials & Textures
 **Goal:** Apply image textures, bump maps, transparency, and environment mapping.
 
-- [01 — Basic Material Types](/06-lesson/01-Basic-material-types.html)  
-- [02 — Colors, Metalness, Roughness](/06-lesson/02-Colors-metalness-roughness.html)  
-- [03 — Apply Wood Texture](/06-lesson/03-Apply-image-texture-wood-canvas.html)  
-- [04 — Color + Bump Map](/06-lesson/04-Color-plus-bump-map-cube.html)  
-- [05 — Transparency + Alpha](/06-lesson/05-Transparency-and-alpha-map-triangle.html)  
-- [06 — Environment Map Reflections](/06-lesson/06-Environment-map-reflections.html)  
-- [07 — Final Polished Scene](/06-lesson/07-Final-polish-combined-scene.html)  
+- [01 — Basic Material Types](/06-lesson/06-01-Basic-material-types.html)
+- [02 — Colors, Metalness, Roughness](/06-lesson/06-02-Colors-metalness-roughness.html)
+- [03 — Apply Wood Texture](/06-lesson/06-03-Apply-image-texture-wood-canvas.html)
+- [04 — Color + Bump Map](/06-lesson/06-04-Color-plus-bump-map-cube.html)
+- [05 — Transparency + Alpha](/06-lesson/06-05-Transparency-and-alpha-map-triangle.html)
+- [06 — Environment Map Reflections](/06-lesson/06-06-Environment-map-reflections.html)
+- [07 — Final Polished Scene](/06-lesson/06-07-Final-polish-combined-scene.html)
 
 📸 _Learner sees: realistic wood, bumpy surfaces, transparent glass, reflective spheres._
 
@@ -139,13 +139,13 @@ Please respect author's hardwork.
 ## 🟨 Lesson 7 — Lighting & Shadows
 **Goal:** Explore lights, shadow types, quality, and shadow materials.
 
-- [01 — Lighting Basics](/07-lesson/01-Lighting-basics.html)  
-- [02 — Directional Light Shadows](/07-lesson/02-Directional-shadows.html)  
-- [03 — Spotlight Shadows](/07-lesson/03-Spotlight-shadows.html)  
-- [04 — Point Light Shadows](/07-lesson/04-Pointlight-shadows.html)  
-- [05 — Shadow Quality & Bias](/07-lesson/05-Shadow-quality-and-bias.html)  
-- [06 — ShadowMaterial & Hemisphere](/07-lesson/06-ShadowMaterial-and-Hemisphere.html)  
-- [07 — Final Lighting Demo](/07-lesson/07-Final.html)  
+- [01 — Lighting Basics](/07-lesson/07-01-Lighting-basics.html)
+- [02 — Directional Light Shadows](/07-lesson/07-02-Directional-shadows.html)
+- [03 — Spotlight Shadows](/07-lesson/07-03-Spotlight-shadows.html)
+- [04 — Point Light Shadows](/07-lesson/07-04-Pointlight-shadows.html)
+- [05 — Shadow Quality & Bias](/07-lesson/07-05-Shadow-quality-and-bias.html)
+- [06 — ShadowMaterial & Hemisphere](/07-lesson/07-06-ShadowMaterial-and-Hemisphere.html)
+- [07 — Final Lighting Demo](/07-lesson/07-07-Final.html)
 
 📸 _Learner sees: multiple light types, shadow tuning, hemisphere light blending._
 
@@ -154,13 +154,13 @@ Please respect author's hardwork.
 ## 🟫 Lesson 8 — Camera Projection Deep Dive
 **Goal:** Master camera types, FOV, zoom vs dolly, and cinematic paths.
 
-- [01 — Camera Types (Perspective vs Ortho)](/08-lesson/01-camera-types.html)  
-- [02 — FOV & Aspect](/08-lesson/02-fov-and-aspect.html)  
-- [03 — Zoom vs Dolly](/08-lesson/03-zoom-vs-dolly.html)  
-- [04 — Fit Camera to Object](/08-lesson/04-fit-camera-to-object.html)  
-- [05 — Screen ↔ World Coordinates](/08-lesson/05-screen-world-coordinates.html)  
-- [06 — Depth of Field Simulation](/08-lesson/06-manual-orbit-and-pan.html)  
-- [07 — Cinematic Camera Path](/08-lesson/07-cinematic-camera-path.html)  
+- [01 — Camera Types (Perspective vs Ortho)](/08-lesson/08-01-camera-types.html)
+- [02 — FOV & Aspect](/08-lesson/08-02-fov-and-aspect.html)
+- [03 — Zoom vs Dolly](/08-lesson/08-03-zoom-vs-dolly.html)
+- [04 — Fit Camera to Object](/08-lesson/08-04-fit-camera-to-object.html)
+- [05 — Screen ↔ World Coordinates](/08-lesson/08-05-screen-world-coordinates.html)
+- [06 — Depth of Field Simulation](/08-lesson/08-06-manual-orbit-and-pan.html)
+- [07 — Cinematic Camera Path](/08-lesson/08-07-cinematic-camera-path.html)
 
 📸 _Learner sees: cameras switching, zoom vs dolly contrast, final cinematic fly-through._
 


### PR DESCRIPTION
## Summary
- update the README lesson overview to point at the renamed HTML files for lessons 1–8
- ensure each link uses the exact casing and numbering found in the lesson folders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d13ae7b2ac8333a680c03160e3412e