### PR TITLE
Add direct step links to lessons 01-10 READMEs

### DIFF
--- a/01-lesson/README.md
+++ b/01-lesson/README.md
@@ -38,7 +38,7 @@ lesson-01-increments/
 
 ## 🗂 Step Breakdown
 
-### Step 01 — Renderer
+### [Step 01 — Renderer](./01-01-renderer.html)
 - Create a WebGL renderer linked to `<canvas>`.
 - Match device pixel ratio for crisp rendering.
 - Clear screen with a dark background color.
@@ -48,7 +48,7 @@ lesson-01-increments/
 
 ---
 
-### Step 02 — Orthographic Camera
+### [Step 02 — Orthographic Camera](./01-02-ortho-camera.html)
 - Add a scene container.
 - Create an **OrthographicCamera** that maps `(0,0)` top-left to `(w,h)` bottom-right.
 - Rebuild camera on resize for consistent pixel mapping.
@@ -57,7 +57,7 @@ lesson-01-increments/
 
 ---
 
-### Step 03 — Square
+### [Step 03 — Square](./01-03-square.html)
 - Create a white square using `PlaneGeometry`.
 - Offset position so `(x,y)` feels like the **top-left corner**.
 - Use `DoubleSide` to avoid disappearing on rotation.
@@ -66,7 +66,7 @@ lesson-01-increments/
 
 ---
 
-### Step 04 — Triangle
+### [Step 04 — Triangle](./01-04-triangle.html)
 - Define a custom path with `Shape` → `lineTo` → `closePath`.
 - Convert with `ShapeGeometry`.
 - Place using top-left corner of bounding box.
@@ -75,7 +75,7 @@ lesson-01-increments/
 
 ---
 
-### Step 05 — Toggles
+### [Step 05 — Toggles](./01-05-toggles.html)
 - Add checkboxes in HTML.
 - Link checkbox state → `mesh.visible`.
 - Initialize with both visible.
@@ -84,7 +84,7 @@ lesson-01-increments/
 
 ---
 
-### Step 06 — Rotate Z
+### [Step 06 — Rotate Z](./01-06-rotate-z.html)
 - Add a button for **Z-axis spin**.
 - Toggle `rotatingZ` flag on click.
 - In loop: `mesh.rotation.z += 0.01`.
@@ -93,7 +93,7 @@ lesson-01-increments/
 
 ---
 
-### Step 07 — Rotate Y
+### [Step 07 — Rotate Y](./01-07-rotate-y.html)
 - Add a button for **Y-axis rotation**.
 - Toggle `rotatingY` flag on click.
 - In loop: `mesh.rotation.y += 0.01`.

--- a/02-lesson/README.md
+++ b/02-lesson/README.md
@@ -9,13 +9,13 @@ This project is licensed under the **UZ Learn Try Personal Education License (UT
 This lesson builds on Lesson 1 and introduces **THREE.Group** for hierarchical transforms.
 
 ## Steps
-1. **Renderer + Ortho Camera** — refresher with blank scene.
-2. **Shapes Refresh** — draw square and triangle.
-3. **Create Group** — make a group and add shapes as children.
-4. **Move Group** — move the entire group with one transform.
-5. **Rotate Group** — toggle rotation for the whole group.
-6. **Group + Individual Animations** — group spins while items rotate independently.
-7. **Toggles: Group vs Items** — buttons to control group vs item rotations separately.
+1. [Step 01 — Renderer + Ortho Camera](./02-01-renderer.html) — refresher with blank scene.
+2. [Step 02 — Shapes Refresh](./02-02-shapes.html) — draw square and triangle.
+3. [Step 03 — Create Group](./02-03-group-create.html) — make a group and add shapes as children.
+4. [Step 04 — Move Group](./02-04-group-move.html) — move the entire group with one transform.
+5. [Step 05 — Rotate Group](./02-05-group-rotate.html) — toggle rotation for the whole group.
+6. [Step 06 — Group + Individual Animations](./02-06-group-and-individual.html) — group spins while items rotate independently.
+7. [Step 07 — Toggles: Group vs Items](./02-07-toggles.html) — buttons to control group vs item rotations separately.
 
 ## Challenges
 - Add a new shape (e.g., a circle) to the group and include it in the rotation logic.

--- a/03-lesson/README.md
+++ b/03-lesson/README.md
@@ -32,6 +32,29 @@ lesson-03-increments/
 └── 07-combine-inputs/         # everything together
 ```
 
+## 🗂 Step Breakdown
+
+### [Step 01 — Renderer](./03-01-renderer.html)
+- Refresh the renderer + orthographic camera scaffolding.
+
+### [Step 02 — Shapes](./03-02-shapes.html)
+- Recreate the square and triangle foundations from earlier lessons.
+
+### [Step 03 — Keys Move Square](./03-03-keys-move-square.html)
+- Use arrow keys to move the square based on keyboard events.
+
+### [Step 04 — Keys Reset (Space)](./03-04-keys-reset-space.html)
+- Add a Space-bar reset that snaps the square back to its start.
+
+### [Step 05 — Mouse Follow Triangle](./03-05-mouse-follow-triangle.html)
+- Make the triangle follow the cursor using mouse position projected into scene space.
+
+### [Step 06 — Hover Highlight](./03-06-hover-highlight.html)
+- Detect hover over each shape and change colors for instant feedback.
+
+### [Step 07 — Combine Inputs](./03-07-combine-inputs.html)
+- Blend keyboard and mouse input so both shapes animate together.
+
 ## 💪 Challenges
 - Add WASD keys to move the triangle independently of the square.
 - Hold **Shift** to temporarily boost movement speed.

--- a/04-lesson/README.md
+++ b/04-lesson/README.md
@@ -25,9 +25,32 @@ lesson-04-increments-fixed/
 ├── 03-toggle-cameras         # button to switch Ortho ↔ Perspective
 ├── 04-z-depth                # place shapes at different Z values
 ├── 05-paired-toggles         # group2D/group3D + checkboxes for pairs
-├── 06-rotating-pairs         # like 05 + rotation in Perspective only
-└── 07-final                  # polished demo (camera toggle + pairs + rotation)
+ ├── 06-rotating-pairs         # like 05 + rotation in Perspective only
+ └── 07-final                  # polished demo (camera toggle + pairs + rotation)
 ```
+
+## 🗂 Step Breakdown
+
+### [Step 01 — Ortho Refresher](./04-01-ortho-refresher.html)
+- Rebuild the centered orthographic camera with helpful axes for orientation.
+
+### [Step 02 — Shapes Ortho](./04-02-shapes-ortho.html)
+- Place the 2D square and triangle at the origin to prep for depth exploration.
+
+### [Step 03 — Toggle Cameras](./04-03-toggle-cameras.html)
+- Add a button to swap between orthographic and perspective views on demand.
+
+### [Step 04 — Z Depth](./04-04-z-depth.html)
+- Push shapes along the Z axis to demonstrate true depth differences.
+
+### [Step 05 — Paired Toggles](./04-05-paired-toggles.html)
+- Organize 2D/3D shape pairs in groups and sync their visibility.
+
+### [Step 06 — Rotating Pairs](./04-06-rotating-pairs.html)
+- Keep the pair toggles and add rotation that only plays in Perspective mode.
+
+### [Step 07 — Final](./04-07-final.html)
+- Deliver the polished camera toggle demo combining depth, groups, and animation.
 
 **File policy:** Each step is a single, self‑contained `.html` file (no bundler needed). All scripts use ESM from the official Three.js CDN.
 

--- a/05-lesson/README.md
+++ b/05-lesson/README.md
@@ -37,25 +37,25 @@ lesson-05/
 
 ## 🧭 7 Steps (quick guide)
 
-### 01 — Scene and 2D shapes
+### [Step 01 — Scene and 2D shapes](./05-01-Scene-and-2D-shapes.html)
 Create a WebGLRenderer + Scene + PerspectiveCamera. Draw a **square** (PlaneGeometry) and a **triangle** (custom BufferGeometry).
 
-### 02 — Add 3D counterparts and lights
+### [Step 02 — Add 3D counterparts and lights](./05-02-Add-3D-counterparts-and-lights.html)
 Add a **cube** + **pyramid** (MeshStandardMaterial) and light them with **Ambient** + **Directional** lights. Tone mapping: **ACESFilmic**.
 
-### 03 — Group + animation
+### [Step 03 — Group + animation](./05-03-Group-and-Animation.html)
 Put all meshes in a `THREE.Group`. Rotate the group and add secondary rotations on cube/pyramid. Use `Clock.getDelta()`.
 
-### 04 — Orthographic camera + hotkeys
+### [Step 04 — Orthographic camera + hotkeys](./05-04-Orthographic-camera-and-switch.html)
 Add **OrthographicCamera** with viewport‑sized frustum. Hotkeys: **1** = Perspective, **2** = Ortho.
 
-### 05 — Orbit controls (drag + wheel)
+### [Step 05 — Orbit controls (drag + wheel)](./05-05-Orbit-controls-drag-and-zoom.html)
 Minimal orbit controller (θ/φ + radius). Drag to orbit, wheel to zoom.
 
-### 06 — DPR‑aware resize
+### [Step 06 — DPR‑aware resize](./05-06-DPR-aware-resize.html)
 Resize the canvas using **devicePixelRatio** (clamped) and update camera projection matrices.
 
-### 07 — HUD + runtime toggles (final)
+### [Step 07 — HUD + runtime toggles (final)](./05-07-HUD-and-runtime-toggles.html)
 Tiny FPS HUD. Runtime flags: toggle rotation (**R**), switch cameras (**1/2**).
 
 ## 💪 Challenges

--- a/06-lesson/README.md
+++ b/06-lesson/README.md
@@ -49,27 +49,27 @@ lesson-06/
 
 ## 🔎 Step‑by‑Step Guide
 
-### **01 — Basic Material Types**
+### [Step 01 — Basic Material Types](./06-01-Basic-material-types.html)
 - Introduces `MeshBasicMaterial` (unlit color) vs. `MeshStandardMaterial` (lit, reacts to lights).
 
-### **02 — Colors, Metalness & Roughness**
+### [Step 02 — Colors, Metalness & Roughness](./06-02-Colors-metalness-roughness.html)
 - Learn how **color**, **metalness**, and **roughness** define a material’s realism.
 - Use keys `C` (cycle color) and `M` (cycle metal/rough presets).
 
-### **03 — Procedural Wood Texture**
+### [Step 03 — Procedural Wood Texture](./06-03-Apply-image-texture-wood-canvas.html)
 - Generate a **wood grain texture** procedurally in Canvas2D and apply it to a plane.
 
-### **04 — Checkerboard + Bump Map**
+### [Step 04 — Checkerboard + Bump Map](./06-04-Color-plus-bump-map-cube.html)
 - Combine a **checker texture** with a **bump map** to add surface relief to a cube.
 
-### **05 — Transparency + Alpha Mask**
+### [Step 05 — Transparency + Alpha Mask](./06-05-Transparency-and-alpha-map-triangle.html)
 - Use `MeshPhysicalMaterial` with `transmission` and a custom **alpha map** to simulate glass.
 
-### **06 — Environment Map Reflections**
+### [Step 06 — Environment Map Reflections](./06-06-Environment-map-reflections.html)
 - Apply a **procedural cube map** as the scene’s background and reflection source.
 - Refine gold material with reflections and clearcoat.
 
-### **07 — Final Polished Scene**
+### [Step 07 — Final Polished Scene](./06-07-Final-polish-combined-scene.html)
 - Bring it all together:
   - **Wooden plane**
   - **Checker cube**

--- a/07-lesson/README.md
+++ b/07-lesson/README.md
@@ -45,28 +45,28 @@ lesson-07/
 
 ## 🔎 Step‑by‑Step Guide
 
-### **01 — Lighting Basics**
+### [Step 01 — Lighting Basics](./07-01-Lighting-basics.html)
 - Adds **AmbientLight** and **DirectionalLight** (no shadows).
 
-### **02 — Directional Shadows**
+### [Step 02 — Directional Shadows](./07-02-Directional-shadows.html)
 - Enable renderer.shadowMap.
 - Configure light.shadow.camera and bias.
 
-### **03 — Spotlight Shadows**
+### [Step 03 — Spotlight Shadows](./07-03-Spotlight-shadows.html)
 - Introduce **SpotLight** with cone angle & target.
 - Moving target shows dynamic shadows.
 
-### **04 — Point Light Shadows**
+### [Step 04 — Point Light Shadows](./07-04-Pointlight-shadows.html)
 - Omni‑directional shadows from a moving **PointLight**.
 
-### **05 — Shadow Quality & Bias**
+### [Step 05 — Shadow Quality & Bias](./07-05-Shadow-quality-and-bias.html)
 - Compare low vs. high quality shadows side by side.
 
-### **06 — ShadowMaterial + Hemisphere**
+### [Step 06 — ShadowMaterial + Hemisphere](./07-06-ShadowMaterial-and-Hemisphere.html)
 - Shadow‑catcher ground using **ShadowMaterial**.
 - Adds soft **HemisphereLight**.
 
-### **07 — Final Polished Scene**
+### [Step 07 — Final Polished Scene](./07-07-Final.html)
 - Mix **Directional + Spot + Point + Hemisphere** lights.
 - Interactive camera orbit.
 - Toggle lights with keys `1,2,3`.

--- a/08-lesson/README.md
+++ b/08-lesson/README.md
@@ -15,13 +15,13 @@ Each step is a **single HTML file** (no npm). All files share the same **scene s
 ---
 
 ## 🗂 Steps Overview
-1. **Perspective vs Orthographic** — swap cameras with **1/2** and see how scale/foreshortening changes.
-2. **FOV & Aspect** — use **[** / **]** to change FOV; resize the window to see aspect impact.
-3. **Zoom vs Dolly** — **Z/X** changes FOV; **W/S** moves the camera in/out; HUD shows FOV vs Distance.
-4. **Fit to Object** — key **1/2/3/0** frames Sphere/Cube/Pyramid/All using a robust `fitCameraToObject` utility.
-5. **Screen ↔ World** — click the ground to drop 3D markers via `Raycaster` (screen → NDC → ray → intersection).
-6. **Simulated Depth of Field** — **↑/↓** adjusts focus distance; objects away from focus gently fade.
-7. **Cinematic Camera Path** — press **Space** to play/pause a fly‑through; **R** to restart; subtle FOV ease.
+1. [Step 01 — Perspective vs Orthographic](./08-01-camera-types.html) — swap cameras with **1/2** and see how scale/foreshortening changes.
+2. [Step 02 — FOV & Aspect](./08-02-fov-and-aspect.html) — use **[** / **]** to change FOV; resize the window to see aspect impact.
+3. [Step 03 — Zoom vs Dolly](./08-03-zoom-vs-dolly.html) — **Z/X** changes FOV; **W/S** moves the camera in/out; HUD shows FOV vs Distance.
+4. [Step 04 — Fit to Object](./08-04-fit-camera-to-object.html) — key **1/2/3/0** frames Sphere/Cube/Pyramid/All using a robust `fitCameraToObject` utility.
+5. [Step 05 — Screen ↔ World](./08-05-screen-world-coordinates.html) — click the ground to drop 3D markers via `Raycaster` (screen → NDC → ray → intersection).
+6. [Step 06 — Simulated Depth of Field](./08-06-manual-orbit-and-pan.html) — **↑/↓** adjusts focus distance; objects away from focus gently fade.
+7. [Step 07 — Cinematic Camera Path](./08-07-cinematic-camera-path.html) — press **Space** to play/pause a fly‑through; **R** to restart; subtle FOV ease.
 
 ## 💪 Challenges
 - Add controls to modify the camera's near and far clipping planes at runtime.
@@ -65,13 +65,13 @@ By the end of Lesson 08, learners can:
 ---
 
 ## 📎 Files (1-per-step)
-- `01-Camera-types-Perspective-vs-Ortho.html`
-- `02-FOV-and-Aspect.html`
-- `03-Zoom-vs-Dolly.html`
-- `04-Fit-Camera-to-Object.html`
-- `05-Screen-World-Coordinates.html`
-- `06-Depth-of-Field.html`
-- `07-Cinematic-Camera-Path.html`
+- `08-01-camera-types.html`
+- `08-02-fov-and-aspect.html`
+- `08-03-zoom-vs-dolly.html`
+- `08-04-fit-camera-to-object.html`
+- `08-05-screen-world-coordinates.html`
+- `08-06-manual-orbit-and-pan.html`
+- `08-07-cinematic-camera-path.html`
 
 Happy coding! ✨
 

--- a/09-lesson/README.md
+++ b/09-lesson/README.md
@@ -18,13 +18,13 @@ We keep the exact **scene, lights, camera, and controls**, and add a chain of **
 ![Pipeline](pipeline.png)
 
 ## 📦 Files (Step 1 → 7)
-- **01 — Composer setup**: Introduces `EffectComposer` and `RenderPass` (replaces `renderer.render`).
-- **02 — FXAA**: Adds `ShaderPass(FXAAShader)` for screen‑space anti‑aliasing; resolution uniform updates on resize.
-- **03 — Bloom**: Adds `UnrealBloomPass` (strength, radius, threshold) and hotkeys to tune it live.
-- **04 — Vignette & Grade**: Custom `ShaderPass` with **lift/gamma/gain** and a vignette mask.
-- **05 — Bokeh DoF**: Adds **depth‑of‑field** with `BokehPass` (focus, aperture).
-- **06 — Chain & Order**: Demonstrates how **FXAA↔Bloom** order changes halo look; single‑view toggle.
-- **07 — Presets & Performance**: Presets (Clean/Filmic/Dreamy/Off), DPR toggle, tiny FPS/ms HUD, clamps & reset.
+- [Step 01 — Composer setup](./09-01-composer-setup.html): Introduces `EffectComposer` and `RenderPass` (replaces `renderer.render`).
+- [Step 02 — FXAA](./09-02-fxaa.html): Adds `ShaderPass(FXAAShader)` for screen‑space anti‑aliasing; resolution uniform updates on resize.
+- [Step 03 — Bloom](./09-03-bloom.html): Adds `UnrealBloomPass` (strength, radius, threshold) and hotkeys to tune it live.
+- [Step 04 — Vignette & Grade](./09-04-vignette-and-grade.html): Custom `ShaderPass` with **lift/gamma/gain** and a vignette mask.
+- [Step 05 — Bokeh DoF](./09-05-bokeh-dof.html): Adds **depth‑of‑field** with `BokehPass` (focus, aperture).
+- [Step 06 — Chain & Order](./09-06-chain-and-order.html): Demonstrates how **FXAA↔Bloom** order changes halo look; single‑view toggle.
+- [Step 07 — Presets & Performance](./09-07-presets-and-performance.html): Presets (Clean/Filmic/Dreamy/Off), DPR toggle, tiny FPS/ms HUD, clamps & reset.
 
 ## 🧠 New concepts
 - **EffectComposer**: a film‑style pipeline of full‑screen passes.

--- a/10-lesson/README.md
+++ b/10-lesson/README.md
@@ -30,25 +30,25 @@ This lesson turns your scene into a **side-view camera system** for a 2D game in
 
 ## Steps at a Glance (1–7)
 
-1. **Step 1 — Ortho Side‑View Base**  
+1. [Step 01 — Ortho Side‑View Base](./10-01-ortho-side-view.html)
    Set up pixel‑consistent **orthographic** camera with **PPU**, gradient sky, minimal scene, player proxy, and **dead‑zone HUD**. Basic critically‑damped follow.
 
-2. **Step 2 — Debug Bars & Parallax Presets**  
+2. [Step 02 — Debug Bars & Parallax Presets](./10-02-pixel-scale-and-safe-area.html)
    Add three columns of **debug bars** (bg/mid/fg) to visualize relative motion. Introduce **parallax presets** (keys 1–4) to compare layer factors quickly.
 
-3. **Step 3 — Repeating BG/FG Tiling**  
+3. [Step 03 — Repeating BG/FG Tiling](./10-03-parallax-layers.html)
    Build small **tile prefabs** for BG/FG and reposition them based on camera to create infinite horizontal looping; optional zebra tint and tile‑bounds toggle.
 
-4. **Step 4 — Density / PPU Control**  
+4. [Step 04 — Density / PPU Control](./10-04-tiling-background.html)
    Hotkeys **K/L** adjust **PIXELS_PER_UNIT**; recompute ortho frustum so world‑to‑pixel mapping remains stable across window sizes and zoom levels.
 
-5. **Step 5 — Dead‑Zone Polish**  
+5. [Step 05 — Dead‑Zone Polish](./10-05-follow-camera-deadzone.html)
    Make DZ size tweakable (`[ ]` width, `; '` height). Fine‑tune spring constants for smooth, responsive camera behavior.
 
-6. **Step 6 — World Bounds & Clamp**  
+6. [Step 06 — World Bounds & Clamp](./10-06-bounds-and-clamp.html)
    Add `{minX,maxX,minY,maxY}` world rectangle. **Clamp** desired camera center by half‑view margins; if **view ≥ world**, **center** instead of clamp. Fix perspective toggle by deriving view from `persp.fov` and refreshing rig immediately.
 
-7. **Step 7 — Visual Presets & Polish**  
+7. [Step 07 — Visual Presets & Polish](./10-07-presets-and-polish.html)
    **Filmic** (DPR‑aware) vs **Pixel‑Art** (DPR=1 + `image-rendering: pixelated` + **pixel‑snap** for camera/player). Optional letterbox mask; keep **single** `applyParallax()` shared by layers, tiles, and bars.
 
 ---


### PR DESCRIPTION
## Summary
- add clickable step links in lessons 01-10 READMEs pointing to the correct HTML increments
- refresh lesson 03 and 04 docs with detailed step breakdown sections
- sync lesson 08 file list with the current HTML filenames

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d13c28f5d08333bb9657020f8f37eb